### PR TITLE
Redesign chat interface

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -1,20 +1,9 @@
 #chat-messages {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 70px;
-    padding: 32px 24px 24px 24px;
+    flex: 1;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
     gap: 18px;
-    background: var(--form-input-bg);
-    max-width: var(--form-max-width);
-    margin: 0 auto;
-    width: 100vw; /* Correction : occupe toute la largeur de la fenêtre */
-    box-sizing: border-box;
-    z-index: 1; /* S'assurer que c'est sous la barre d'entrée */
 }
 
 .message {
@@ -37,14 +26,15 @@
     align-items: center;
     justify-content: center;
     color: var(--form-btn-color);
+    background: var(--form-btn-bg);
     font-weight: bold;
     font-size: 1.1rem;
     font-family: 'Inter', Arial, sans-serif;
 }
 
 .message .bubble {
-    background: #444654;
-    color: var(--form-input-color);
+    background: #e3e8f0;
+    color: var(--text-color);
     padding: 14px 18px;
     border-radius: 12px;
     font-size: 1.05rem;
@@ -53,5 +43,6 @@
 }
 
 .message.user .bubble {
+    background: var(--form-btn-bg);
     color: #fff;
 }

--- a/css/form.css
+++ b/css/form.css
@@ -1,93 +1,95 @@
 .messageBox {
     position: fixed;
     left: 50%;
-    bottom: 10px;
-    top: unset;
+    bottom: 20px;
     transform: translateX(-50%);
     z-index: 1000;
-    width: fit-content;
-    height: 50px; /* ajusté pour correspondre à la marge dans .atlas-messages */
+    width: calc(100% - 40px);
+    max-width: var(--form-max-width);
     display: flex;
     align-items: center;
-    justify-content: center;
-    background-color: #2d2d2d;
-    padding: 0 15px;
-    border-radius: 10px;
-    border: 1px solid rgb(63, 63, 63);
+    gap: 10px;
+    background-color: var(--form-bg);
+    padding: 8px 12px;
+    border-radius: var(--form-radius);
+    border: var(--form-border);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .messageBox:focus-within {
-  border: 1px solid rgb(110, 110, 110);
+    border-color: var(--form-btn-bg);
 }
 
 .fileUploadWrapper {
-  width: fit-content;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: 'Inter', Arial, Helvetica, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+
+.fileUploadWrapper label {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
 }
 
 #file {
-  display: none;
+    display: none;
 }
 
 .tooltip {
-  position: absolute;
-  top: -40px;
-  display: none;
-  opacity: 0;
-  color: white;
-  font-size: 10px;
-  text-wrap: nowrap;
-  background-color: #000;
-  padding: 6px 10px;
-  border: 1px solid #3c3c3c;
-  border-radius: 5px;
-  box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.596);
-  transition: all 0.3s;
+    position: absolute;
+    top: -40px;
+    display: none;
+    opacity: 0;
+    color: white;
+    font-size: 10px;
+    white-space: nowrap;
+    background-color: #000;
+    padding: 6px 10px;
+    border-radius: 5px;
+    box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.596);
+    transition: all 0.3s;
+}
+
+.fileUploadWrapper:hover .tooltip {
+    display: block;
+    opacity: 0.8;
 }
 
 #messageInput {
-  width: 200px;
-  height: 100%;
-  background-color: transparent;
-  outline: none;
-  border: none;
-  padding-left: 10px;
-  color: white;
+    flex: 1;
+    background-color: transparent;
+    outline: none;
+    border: none;
+    color: var(--form-input-color);
+    font-size: 1rem;
+    padding-left: 8px;
 }
 
 #messageInput:focus ~ #sendButton svg path,
 #messageInput:valid ~ #sendButton svg path {
-  fill: #3c3c3c;
-  stroke: white;
+    fill: #3c3c3c;
+    stroke: white;
 }
 
 #sendButton {
-  width: fit-content;
-  height: 100%;
-  background-color: transparent;
-  outline: none;
-  border: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: all 0.3s;
+    background-color: transparent;
+    outline: none;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.3s;
 }
 
 #sendButton svg {
-  height: 18px;
-  transition: all 0.3s;
-}
-
-#sendButton svg path {
-  transition: all 0.3s;
+    height: 18px;
+    transition: all 0.3s;
 }
 
 #sendButton:hover svg path {
-  fill: #3c3c3c;
-  stroke: white;
+    fill: #3c3c3c;
+    stroke: white;
 }

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,10 +1,30 @@
 body {
     font-family: 'Inter', Arial, sans-serif;
-    background: var(--form-input-bg);
-    color: var(--form-input-color);
+    background: var(--bg-color);
+    color: var(--text-color);
     margin: 0;
     padding: 0;
+    display: flex;
+    flex-direction: column;
     min-height: 100vh;
+}
+
+.app-header {
+    background: var(--form-btn-bg);
+    color: #fff;
+    padding: 16px 20px;
+    text-align: center;
+    font-size: 1.3rem;
+    font-weight: 600;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.chat-container {
+    flex: 1;
+    width: 100%;
+    max-width: var(--form-max-width);
+    margin: 0 auto;
+    padding: 24px;
     display: flex;
     flex-direction: column;
 }

--- a/css/toast.css
+++ b/css/toast.css
@@ -1,6 +1,6 @@
 #toast-container {
     position: fixed;
-    bottom: 32px;
+    bottom: 80px;
     left: 50%;
     transform: translateX(-50%);
     z-index: 9999;
@@ -12,8 +12,8 @@
 }
 
 .toast {
-    background: var(--form-input-bg);
-    color: var(--form-input-color);
+    background: var(--form-bg);
+    color: var(--text-color);
     padding: 16px 28px;
     border-radius: var(--form-radius);
     box-shadow: 0 2px 12px rgba(0,0,0,0.18);

--- a/css/variable.css
+++ b/css/variable.css
@@ -1,14 +1,16 @@
 :root {
-    --form-bg: #2d2d2d;
-    --form-radius: 7px;
+    --bg-color: #f0f2f5;
+    --text-color: #222;
+    --form-bg: #ffffff;
+    --form-radius: 8px;
     --form-padding: 10px;
     --form-gap: 10px;
     --form-max-width: 900px;
-    --form-border: 1px solid #353740;
-    --form-input-bg: #2d2d2d;
-    --form-input-color: #ececf1;
-    --form-btn-bg: #19c37d;
-    --form-btn-bg-hover: #13a06d;
+    --form-border: 1px solid #d0d0d0;
+    --form-input-bg: #ffffff;
+    --form-input-color: #222;
+    --form-btn-bg: #4b6cb7;
+    --form-btn-bg-hover: #3956a3;
     --form-btn-color: #fff;
     --form-btn-radius: 6px;
 }

--- a/index.html
+++ b/index.html
@@ -2,57 +2,37 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>ATLAS - Interface</title>
+    <title>ATLAS Chat</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="css/style.css">
     <meta name="google" content="notranslate">
     <meta http-equiv="Content-Language" content="en">
 </head>
-<body style="min-height:100vh;">
-    <div class="atlas-messages" id="chat-messages"></div>
+<body>
+    <header class="app-header">
+        <h1>ATLAS Chat</h1>
+    </header>
+    <main class="chat-container">
+        <div id="chat-messages" class="atlas-messages"></div>
+    </main>
     <form id="atlas-form" autocomplete="off">
         <div class="messageBox">
             <div class="fileUploadWrapper">
                 <label for="file">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 337 337">
-                        <circle
-                        stroke-width="20"
-                        stroke="#6c6c6c"
-                        fill="none"
-                        r="158.5"
-                        cy="168.5"
-                        cx="168.5"
-                        ></circle>
-                        <path
-                        stroke-linecap="round"
-                        stroke-width="25"
-                        stroke="#6c6c6c"
-                        d="M167.759 79V259"
-                        ></path>
-                        <path
-                        stroke-linecap="round"
-                        stroke-width="25"
-                        stroke="#6c6c6c"
-                        d="M79 167.138H259"
-                        ></path>
+                        <circle stroke-width="20" stroke="#6c6c6c" fill="none" r="158.5" cy="168.5" cx="168.5"></circle>
+                        <path stroke-linecap="round" stroke-width="25" stroke="#6c6c6c" d="M167.759 79V259"></path>
+                        <path stroke-linecap="round" stroke-width="25" stroke="#6c6c6c" d="M79 167.138H259"></path>
                     </svg>
                     <span class="tooltip">Add an image</span>
                 </label>
                 <input type="file" id="file" name="file" />
             </div>
-            <input required="" placeholder="Message..." type="text" id="messageInput" name="prompt" />
+            <input required placeholder="Message..." type="text" id="messageInput" name="prompt" />
             <button id="sendButton" type="submit">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 664 663">
-                <path
-                    fill="none"
-                    d="M646.293 331.888L17.7538 17.6187L155.245 331.888M646.293 331.888L17.753 646.157L155.245 331.888M646.293 331.888L318.735 330.228L155.245 331.888"
-                ></path>
-                <path
-                    stroke-linejoin="round"
-                    stroke-linecap="round"
-                    stroke-width="33.67"
-                    stroke="#6c6c6c"
-                    d="M646.293 331.888L17.7538 17.6187L155.245 331.888M646.293 331.888L17.753 646.157L155.245 331.888M646.293 331.888L318.735 330.228L155.245 331.888"
-                ></path>
+                    <path fill="none" d="M646.293 331.888L17.7538 17.6187L155.245 331.888M646.293 331.888L17.753 646.157L155.245 331.888M646.293 331.888L318.735 330.228L155.245 331.888" />
+                    <path stroke-linejoin="round" stroke-linecap="round" stroke-width="33.67" stroke="#6c6c6c" d="M646.293 331.888L17.7538 17.6187L155.245 331.888M646.293 331.888L17.753 646.157L155.245 331.888M646.293 331.888L318.735 330.228L155.245 331.888" />
                 </svg>
             </button>
         </div>


### PR DESCRIPTION
## Summary
- revamp index.html layout with header and main chat container
- overhaul CSS with new color scheme and responsive layout
- remove unused messagebox.css

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6863208e92b88333821010e030c00cd9